### PR TITLE
fix: use Reanimated's requestAnimationFrame in worklets

### DIFF
--- a/src/hooks/useAnimatedTimeout.ts
+++ b/src/hooks/useAnimatedTimeout.ts
@@ -1,4 +1,4 @@
-import { makeMutable } from 'react-native-reanimated';
+import { makeMutable, requestAnimationFrame } from 'react-native-reanimated';
 
 type AnyFunction = (...args: any[]) => any;
 


### PR DESCRIPTION
## Problem

`setAnimatedTimeout` in `src/hooks/useAnimatedTimeout.ts` is marked with the `'worklet'` directive, meaning it runs on the Reanimated UI thread. However, it calls the global `requestAnimationFrame`, which is **not available in the worklet runtime** — only on the JS thread.

This causes a fatal `facebook::jsi::JSError` crash whenever the confetti animation's internal timing fires. In our case, every new user going through onboarding was crashing ~1 second after the confetti component mounted.

**Stack trace:**
```
Fatal Exception: facebook::jsi::JSError
hermes HermesRuntimeImpl::throwPendingError()
hermes HermesRuntimeImpl::call()
worklets::WorkletRuntime::runSync()
worklets::scheduleOnUI()
worklets::UIScheduler::triggerUI()
worklets::IOSUIScheduler::scheduleOnUI()
```

**Environment:** react-native-reanimated 4.1.6, Hermes, iOS

## Fix

Import `requestAnimationFrame` from `react-native-reanimated` instead of relying on the global. Reanimated exports a worklet-compatible implementation that properly schedules frame callbacks on the UI thread.

```diff
-import { makeMutable } from 'react-native-reanimated';
+import { makeMutable, requestAnimationFrame } from 'react-native-reanimated';
```