### PR TITLE
fix(Confetti): guarantee sprites.length === count to prevent Skia Atlas crash

### DIFF
--- a/src/Confetti.tsx
+++ b/src/Confetti.tsx
@@ -189,6 +189,7 @@ const InternalConfetti = forwardRef<ConfettiMethods, InternalConfettiProps>(
       sizeVariations,
       colors,
       boxes,
+      count,
       textureProps:
         flakeProps.type === 'image' && flakeProps.flakeImage
           ? { type: 'image', content: flakeProps.flakeImage }

--- a/src/Confetti.tsx
+++ b/src/Confetti.tsx
@@ -136,6 +136,7 @@ const ConfettiInner = forwardRef<ConfettiMethods, InternalConfettiProps>(
       colors: allColors,
       boxes,
       sizeColorOverrides: colorOverrides,
+      count,
     });
 
     const sizeVariationsCount = sizeVariations.length;

--- a/src/PIConfetti.tsx
+++ b/src/PIConfetti.tsx
@@ -98,6 +98,7 @@ const PIConfetti = forwardRef<PIConfettiMethods, PIConfettiProps>(
       sizeVariations,
       colors,
       boxes,
+      count,
       textureProps:
         flakeProps.type === 'image' && flakeProps.flakeImage
           ? { type: 'image', content: flakeProps.flakeImage }

--- a/src/PIConfetti.tsx
+++ b/src/PIConfetti.tsx
@@ -125,6 +125,7 @@ const PIConfettiInner = forwardRef<PIConfettiMethods, PIConfettiProps>(
       colors: allColors,
       boxes,
       sizeColorOverrides: colorOverrides,
+      count: totalCount,
     });
 
     const refreshBoxes = useCallback(() => {

--- a/src/hooks/useConfettiLogic.tsx
+++ b/src/hooks/useConfettiLogic.tsx
@@ -23,6 +23,7 @@ export const useConfettiLogic = <T extends MinimalBox>({
   colors,
   boxes,
   textureProps,
+  count,
 }: {
   colors: Strict<ConfettiProps['colors']>;
   boxes: SharedValue<T[]>;
@@ -40,6 +41,7 @@ export const useConfettiLogic = <T extends MinimalBox>({
         type: 'svg';
         content: SkSVG;
       };
+  count?: number;
 }) => {
   const maxWidth = Math.max(...sizeVariations.map((size) => size.width));
   const maxHeight = Math.max(...sizeVariations.map((size) => size.height));
@@ -93,17 +95,28 @@ export const useConfettiLogic = <T extends MinimalBox>({
   );
 
   const sprites = useDerivedValue(() => {
-    return boxes.get().map((box) => {
-      const colorIndex = box.colorIndex;
-      const sizeIndex = box.sizeIndex;
-      const size = sizeVariations[sizeIndex]!;
-      return rect(
-        sizeIndex * maxWidth,
-        colorIndex * maxHeight,
+    const current = boxes.get();
+    const n = count ?? current.length;
+    const result = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const box = current[i];
+      if (!box) {
+        result[i] = rect(0, 0, 0, 0);
+        continue;
+      }
+      const size = sizeVariations[box.sizeIndex];
+      if (!size) {
+        result[i] = rect(0, 0, 0, 0);
+        continue;
+      }
+      result[i] = rect(
+        box.sizeIndex * maxWidth,
+        box.colorIndex * maxHeight,
         size.width,
         size.height
       );
-    });
+    }
+    return result;
   });
 
   return {

--- a/src/hooks/useConfettiLogic.tsx
+++ b/src/hooks/useConfettiLogic.tsx
@@ -115,11 +115,13 @@ export const useConfettiLogic = <T extends MinimalBox>({
   colors,
   boxes,
   sizeColorOverrides,
+  count,
 }: {
   colors: string[];
   boxes: SharedValue<T[]>;
   sizeVariations: SizeVariation[];
   sizeColorOverrides: (ColorRange | null)[];
+  count?: number;
 }) => {
   const maxWidth = Math.max(...sizeVariations.map((size) => size.width));
   const maxHeight = Math.max(...sizeVariations.map((size) => size.height));
@@ -143,18 +145,28 @@ export const useConfettiLogic = <T extends MinimalBox>({
   );
 
   const sprites = useDerivedValue(() => {
-    return boxes.get().map((box) => {
-      const colorIndex = box.colorIndex;
-      const sizeIndex = box.sizeIndex;
-      const size = sizeVariations[sizeIndex];
-      if (!size) return rect(0, 0, 0, 0);
-      return rect(
-        sizeIndex * maxWidth,
-        colorIndex * maxHeight,
+    const current = boxes.get();
+    const n = count ?? current.length;
+    const result = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const box = current[i];
+      if (!box) {
+        result[i] = rect(0, 0, 0, 0);
+        continue;
+      }
+      const size = sizeVariations[box.sizeIndex];
+      if (!size) {
+        result[i] = rect(0, 0, 0, 0);
+        continue;
+      }
+      result[i] = rect(
+        box.sizeIndex * maxWidth,
+        box.colorIndex * maxHeight,
         size.width,
         size.height
       );
-    });
+    }
+    return result;
   });
 
   return {


### PR DESCRIPTION
## Summary
Skia's <Atlas> requires sprites.length === transforms.length. When
boxes is empty or out of sync with count (e.g. count changes, or
deferred-layout scenarios like `<Modal>`), Atlas throws:

  Exception in HostFunction: transforms and sprites arrays must have the same length

This PR pads the sprites derived value to exactly `count` entries,
filling unused slots with `rect(0, 0, 0, 0)` (zero-size, invisible),
so the two arrays are always length-matched on every commit.

## Changes
- `src/hooks/useConfettiLogic.tsx` — add optional `count?: number` param;
  sprites derived value always returns `count ?? boxes.get().length`
  entries, padding missing/invalid slots with `rect(0, 0, 0, 0)`.
- `src/Confetti.tsx` — pass `count`.
- `src/PIConfetti.tsx` — pass `count` (consistency).

The `count` param is optional with a fallback to `boxes.get().length`,
so external callers are unaffected.

## Risk
Very low. Once boxes is populated (steady state) every slot is a real
rect and output is byte-identical to before. Unused slots render as
`rect(0, 0, 0, 0)`, which Skia's Atlas draws as nothing.

## Test plan
- [x] `<Confetti>` inside a `<Modal>` no longer throws on open
- [x] Example app renders identically (default flakes, image texture, SVG texture)
- [x] autoplay={false} + imperative restart() still works
- [x] isContinuous and isInfinite variants unchanged
- [x] Android + iOS with @shopify/react-native-skia 2.2.x

