### PR TITLE
fix: cancel running animation when the component unmounts (native Skia crashes)

### DIFF
--- a/src/hooks/useAnimationLifecycle.ts
+++ b/src/hooks/useAnimationLifecycle.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 import {
   cancelAnimation,
   Easing,
@@ -46,6 +46,22 @@ export const useAnimationLifecycle = ({
     onAnimationStart,
     onAnimationEnd
   );
+
+  useLayoutEffect(() => {
+    return () => {
+      // Stop the UI-thread animation before React tears down the Skia canvas:
+      // an in-flight withTiming otherwise keeps driving Atlas renders during
+      // unmount and races the surface destruction (native crashes on both
+      // platforms: GrResourceCache EXC_BREAKPOINT on iOS, JsiSkSurface::flush
+      // SIGTRAP on Android).
+      // A layout effect is required: its cleanup runs in React's deletion
+      // phase BEFORE host views are removed, whereas a passive useEffect
+      // cleanup would run after the canvas is already destroyed.
+      running.set(false);
+      cancelAnimation(progress);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const opacity = useDerivedValue(() => {
     if (!fadeOutOnEnd) return 1;


### PR DESCRIPTION
**Authorship note:** this fix was diagnosed and written by Claude (Anthropic's Fable 5 model, an AI) working in our production codebase; I (the account owner) reviewed it and am submitting it.

## Problem

`useAnimationLifecycle` starts `withTiming` on the `progress` shared value but never cancels it on unmount. If `CannonConfetti` unmounts while a burst is still running (navigation, closing a modal), the animation keeps ticking on the UI thread and the reanimated-driven `<Atlas>` bindings keep triggering Skia renders while React destroys the Canvas and its `SkSurface`.

In production (we fire confetti after every completed exercise) this produced hard native crashes on both platforms within days:

- **iOS** — `EXC_BREAKPOINT` in Skia's GPU resource cache:
  `RNSkia::RNSkView::requestRedraw → RNSkPictureRenderer::renderImmediate → SkSurface_Ganesh::~SkSurface_Ganesh → GrResourceCache::notifyARefCntReachedZero`
- **Android** — `SIGTRAP`:
  `worklets::UIScheduler::triggerUI → … → RNSkia::JsiSkSurface::flush` (and a sibling crash group in `RNSkia::JsiSkCanvas::~JsiSkCanvas`)

Observed on react-native-fast-confetti 2.0.1 with RN 0.81 / New Architecture / reanimated 4.1 / skia 2.6.9, and previously on RN 0.79 / old architecture / reanimated 3 / skia 2.0 — so it isn't version- or architecture-specific.

## Fix

Cancel the animation in a `useLayoutEffect` cleanup. The layout effect matters: React runs layout-effect cleanups during the deletion phase, **before** it removes the subtree's host views, while passive `useEffect` cleanups run after the commit — after the Skia canvas is already gone, which would leave the race window open.

We've been running exactly this change in production via `patch-package`.

Happy to add a jest test for the unmount path if you'd like — didn't want to guess at your preferred reanimated mocking setup.
